### PR TITLE
New SQLAlchemy version and applied unused port

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,4 +122,4 @@ def copyright():
    return render_template('copyright.html')
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5010)
+    app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -122,4 +122,4 @@ def copyright():
    return render_template('copyright.html')
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, port=5010)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Werkzeug==2.1.2
 google-cloud-translate
 nepali-unicode-converter
 nepali-roman
-Flask-SQLAlchemy
+Flask-SQLAlchemy==1.4


### PR DESCRIPTION
For regenerating the sqlalchemy issue, clone ashimdahal/jelly and run in isolated virtual environment.


![jelly](https://user-images.githubusercontent.com/66795857/229728179-70c340e4-c0ad-4e45-984a-e3118f9fa291.png)

Also, after solving this issue, I got an error for port already in use and 5000 which is the default port for flask can be used most of the time. So, to resolve this issue, I added the port=5010 parameter to the app.run.
![jelly2](https://user-images.githubusercontent.com/66795857/229729066-9d7bb4e6-1ba0-4582-9346-b4552a03d612.png)
